### PR TITLE
Silence -Wimplicit-function-declaration.

### DIFF
--- a/hexbin/hexbin.c
+++ b/hexbin/hexbin.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <time.h>
 #include "globals.h"
 #include "crc.h"
 #include "readline.h"

--- a/macunpack/dia.c
+++ b/macunpack/dia.c
@@ -5,6 +5,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include "globals.h"
 #include "../util/curtime.h"
 #include "../util/masks.h"

--- a/macunpack/stf.c
+++ b/macunpack/stf.c
@@ -2,6 +2,7 @@
 #ifdef STF
 #include <string.h>
 #include <stdlib.h>
+#include <time.h>
 #include "stf.h"
 #include "globals.h"
 #include "huffman.h"


### PR DESCRIPTION
If the -DBSD cf macro is specified, GCC 14 fails on an implicit definition of time.

This should be harmless--it doesn't break builds with the default cf macros, and time.h is included in POSIX.